### PR TITLE
Fix overlay color default in hero slider schema

### DIFF
--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -318,7 +318,7 @@
 
         { "type": "checkbox", "id": "enable_shimmer", "label": "Shimmer heading", "default": false },
 
-        { "type": "color", "id": "overlay_color", "label": "Overlay color (override)", "default": "" },
+        { "type": "color", "id": "overlay_color", "label": "Overlay color (override)", "default": "#000000" },
         { "type": "range", "id": "overlay_opacity", "min": 0, "max": 95, "step": 1, "unit": "%", "label": "Overlay opacity (override)", "default": 0 },
         { "type": "select", "id": "overlay_blend", "label": "Overlay blend (override)", "default": "inherit", "options": [
           { "value": "inherit", "label": "Inherit section" },


### PR DESCRIPTION
## Summary
- set slide overlay color default to `#000000`

## Testing
- `npx theme-check sections/pro_agg_hero_slider.liquid` *(fails: could not determine executable to run)*
- `theme-check sections/pro_agg_hero_slider.liquid` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0deb482b8832eb86c8a5aa2734eae