### PR TITLE
fix: limit hero slider overlay angle steps

### DIFF
--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -250,7 +250,7 @@
         {"type": "color", "id": "overlay_color", "label": "Overlay color"},
         {"type": "color", "id": "overlay_color_start", "label": "Gradient start"},
         {"type": "color", "id": "overlay_color_end", "label": "Gradient end"},
-        {"type": "range", "id": "overlay_angle", "label": "Gradient angle", "min": 0, "max": 360, "step": 1, "default": 180},
+        {"type": "range", "id": "overlay_angle", "label": "Gradient angle", "min": 0, "max": 360, "step": 5, "default": 180},
         {"type": "range", "id": "overlay_opacity", "label": "Overlay opacity", "min": 0, "max": 100, "step": 1, "default": 50},
 
         {"type": "header", "content": "Heading"},


### PR DESCRIPTION
## Summary
- ensure hero slider overlay angle uses 5-degree step to satisfy Shopify's 101-step limit

## Testing
- `theme-check | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_b_68a175f33948832ebd2b5cf9370c4d2b