### PR TITLE
feat: add hero slider section

### DIFF
--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -1,4 +1,4 @@
-<div class="pro-agg-slider slider--{{ section.settings.slide_height }}">
+<div class="pro-agg-slider slider--{{ section.settings.slide_height }}" role="region" aria-label="Hero slider" aria-live="polite">
   {% for block in section.blocks %}
     <div class="slide" {{ block.shopify_attributes }}>
       {% if block.settings.image != blank %}

--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -1,0 +1,108 @@
+<div class="pro-agg-slider slider--{{ section.settings.slide_height }}">
+  {% for block in section.blocks %}
+    <div class="slide" {{ block.shopify_attributes }}>
+      {% if block.settings.image != blank %}
+        <img src="{{ block.settings.image | image_url }}" loading="lazy" alt="{{ block.settings.image_alt }}">
+      {% endif %}
+      <div class="slide-content box-{{ block.settings.box_align }}">
+        {% if block.settings.heading != blank %}
+          <h2>{{ block.settings.heading }}</h2>
+        {% endif %}
+        {% if block.settings.subheading != blank %}
+          <p>{{ block.settings.subheading }}</p>
+        {% endif %}
+        {% if block.settings.button_1_label != blank %}
+          <a href="{{ block.settings.button_1_url }}">{{ block.settings.button_1_label }}</a>
+        {% endif %}
+        {% if block.settings.button_2_label != blank %}
+          <a href="{{ block.settings.button_2_url }}">{{ block.settings.button_2_label }}</a>
+        {% endif %}
+      </div>
+    </div>
+  {% endfor %}
+  {% if section.settings.show_arrows %}
+    <button type="button" class="slider-arrow prev" aria-label="Previous">&#10094;</button>
+    <button type="button" class="slider-arrow next" aria-label="Next">&#10095;</button>
+  {% endif %}
+  {% if section.settings.show_dots %}
+    <div class="slider-dots">
+      {% for block in section.blocks %}
+        <button class="dot" aria-label="Go to slide {{ forloop.index }}"></button>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>
+
+{% schema %}
+{
+  "name": "Hero slider",
+  "settings": [
+    {
+      "type": "select",
+      "id": "slide_height",
+      "label": "Slide height",
+      "options": [
+        { "value": "small", "label": "Small" },
+        { "value": "medium", "label": "Medium" },
+        { "value": "large", "label": "Large" }
+      ],
+      "default": "medium"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_arrows",
+      "label": "Show arrows",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_dots",
+      "label": "Show dots",
+      "default": true
+    }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        { "type": "image_picker", "id": "image", "label": "Image" },
+        { "type": "text", "id": "image_alt", "label": "Image alt text" },
+        { "type": "text", "id": "heading", "label": "Heading" },
+        { "type": "text", "id": "subheading", "label": "Subheading" },
+        { "type": "text", "id": "button_1_label", "label": "Button 1 label" },
+        { "type": "url", "id": "button_1_url", "label": "Button 1 URL" },
+        { "type": "text", "id": "button_2_label", "label": "Button 2 label" },
+        { "type": "url", "id": "button_2_url", "label": "Button 2 URL" },
+        {
+          "type": "select",
+          "id": "box_align",
+          "label": "Content position",
+          "options": [
+            { "value": "top_left", "label": "Top left" },
+            { "value": "top_center", "label": "Top center" },
+            { "value": "top_right", "label": "Top right" },
+            { "value": "middle_left", "label": "Middle left" },
+            { "value": "middle_center", "label": "Middle center" },
+            { "value": "middle_right", "label": "Middle right" },
+            { "value": "bottom_left", "label": "Bottom left" },
+            { "value": "bottom_center", "label": "Bottom center" },
+            { "value": "bottom_right", "label": "Bottom right" }
+          ],
+          "default": "middle_center"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 10,
+  "presets": [
+    {
+      "name": "Hero slider",
+      "blocks": [
+        { "type": "slide" },
+        { "type": "slide" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -15,7 +15,10 @@
           <a href="{{ block.settings.button_1_url }}">{{ block.settings.button_1_label }}</a>
         {% endif %}
         {% if block.settings.button_2_label != blank %}
-          <a href="{{ block.settings.button_2_url }}">{{ block.settings.button_2_label }}</a>
+          <a href="{{ block.settings.button_1_url }}" role="button" tabindex="0">{{ block.settings.button_1_label }}</a>
+        {% endif %}
+        {% if block.settings.button_2_label != blank %}
+          <a href="{{ block.settings.button_2_url }}" role="button" tabindex="0">{{ block.settings.button_2_label }}</a>
         {% endif %}
       </div>
     </div>
@@ -27,7 +30,7 @@
   {% if section.settings.show_dots %}
     <div class="slider-dots">
       {% for block in section.blocks %}
-        <button class="dot" aria-label="Go to slide {{ forloop.index }}"></button>
+        <button class="dot" aria-label="Go to slide {{ forloop.index }}"{% if forloop.first %} aria-current="true"{% endif %}></button>
       {% endfor %}
     </div>
   {% endif %}

--- a/sections/pro_agg_hero_slider.liquid
+++ b/sections/pro_agg_hero_slider.liquid
@@ -2,7 +2,7 @@
   {% for block in section.blocks %}
     <div class="slide" {{ block.shopify_attributes }}>
       {% if block.settings.image != blank %}
-        <img src="{{ block.settings.image | image_url }}" loading="lazy" alt="{{ block.settings.image_alt }}">
+        <img src="{{ block.settings.image | image_url }}" loading="lazy" alt="{{ block.settings.image_alt | default: block.settings.heading | default: 'Slide image' }}">
       {% endif %}
       <div class="slide-content box-{{ block.settings.box_align }}">
         {% if block.settings.heading != blank %}


### PR DESCRIPTION
## Summary
- add `pro_agg_hero_slider` section with image slides, content blocks, arrows and dots

## Testing
- `theme-check sections/pro_agg_hero_slider.liquid` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a17cf83a9c832ea6b02c4103fca652