### PR TITLE
Add configurable hero slider section

### DIFF
--- a/assets/pro-agg-hero-slider.css
+++ b/assets/pro-agg-hero-slider.css
@@ -1,0 +1,18 @@
+/* Styles for Pro AGG Hero Slider */
+.pro-agg-hero-slider__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.banner--content-align-left .pro-agg-hero-slider__buttons {
+  justify-content: flex-start;
+}
+
+.banner--content-align-center .pro-agg-hero-slider__buttons {
+  justify-content: center;
+}
+
+.banner--content-align-right .pro-agg-hero-slider__buttons {
+  justify-content: flex-end;
+}

--- a/assets/pro-agg-hero-slider.js
+++ b/assets/pro-agg-hero-slider.js
@@ -1,0 +1,3 @@
+/* Custom scripts for Pro AGG Hero Slider */
+
+/* Placeholder for future enhancements */

--- a/sections/pro-agg-hero-slider.liquid
+++ b/sections/pro-agg-hero-slider.liquid
@@ -1,0 +1,158 @@
+{{ 'pro-agg-hero-slider.css' | asset_url | stylesheet_tag }}
+{{ 'pro-agg-hero-slider.js' | asset_url | script_tag }}
+
+<slideshow-component
+  class="slider-mobile-gutter{% if section.settings.layout == 'grid' %} page-width{% endif %}{% if section.settings.show_text_below %} mobile-text-below{% endif %}"
+  data-autoplay="{{ section.settings.auto_rotate }}"
+  data-speed="{{ section.settings.change_slides_speed }}"
+  role="region"
+  aria-roledescription="{{ 'sections.slideshow.carousel' | t }}"
+  aria-label="{{ 'sections.slideshow.carousel' | t }}"
+>
+  {%- if section.blocks.size > 1 -%}
+    <div class="slideshow__controls slider-buttons">
+      <button
+        type="button"
+        class="slider-button slider-button--prev"
+        name="previous"
+        aria-label="{{ 'sections.slideshow.previous_slideshow' | t }}"
+        aria-controls="Slider-{{ section.id }}"
+      >
+        <span class="svg-wrapper">
+          {{- 'icon-caret.svg' | inline_asset_content -}}
+        </span>
+      </button>
+      <button
+        type="button"
+        class="slider-button slider-button--next"
+        name="next"
+        aria-label="{{ 'sections.slideshow.next_slideshow' | t }}"
+        aria-controls="Slider-{{ section.id }}"
+      >
+        <span class="svg-wrapper">
+          {{- 'icon-caret.svg' | inline_asset_content -}}
+        </span>
+      </button>
+    </div>
+  {%- endif -%}
+
+  <div
+    class="pro-agg-hero-slider banner slider slider--everywhere"
+    id="Slider-{{ section.id }}"
+    aria-live="polite"
+    aria-atomic="true"
+    data-autoplay="{{ section.settings.auto_rotate }}"
+    data-speed="{{ section.settings.change_slides_speed }}"
+  >
+    {%- for block in section.blocks -%}
+      <style>
+        #Slide-{{ section.id }}-{{ forloop.index }} .banner__media::after {
+          opacity: {{ block.settings.image_overlay_opacity | divided_by: 100.0 }};
+        }
+      </style>
+      <div
+        class="slideshow__slide slider__slide"
+        id="Slide-{{ section.id }}-{{ forloop.index }}"
+        role="group"
+        aria-roledescription="{{ 'sections.slideshow.slide' | t }}"
+        aria-label="{{ forloop.index }} / {{ forloop.length }}"
+        {{ block.shopify_attributes }}
+      >
+        <div class="banner banner--content-align-{{ block.settings.text_alignment }} banner--content-align-mobile-{{ block.settings.text_alignment_mobile }}">
+          {%- if block.settings.image != blank -%}
+            <div class="banner__media media">
+              {{ block.settings.image | image_url: width: 3840 | image_tag: loading: 'lazy', width: block.settings.image.width, height: block.settings.image.height }}
+            </div>
+          {%- else -%}
+            <div class="banner__media media placeholder"></div>
+          {%- endif -%}
+          <div class="banner__content">
+            <div class="banner__box">
+              {%- if block.settings.heading != blank -%}
+                <h2 class="banner__heading">{{ block.settings.heading }}</h2>
+              {%- endif -%}
+              {%- if block.settings.text != blank -%}
+                <div class="banner__text">{{ block.settings.text }}</div>
+              {%- endif -%}
+              <div class="pro-agg-hero-slider__buttons banner__buttons--multiple">
+                {%- if block.settings.button_label_1 != blank -%}
+                  <a href="{{ block.settings.button_link_1 }}" class="button">{{ block.settings.button_label_1 }}</a>
+                {%- endif -%}
+                {%- if block.settings.button_label_2 != blank -%}
+                  <a href="{{ block.settings.button_link_2 }}" class="button button--secondary">{{ block.settings.button_label_2 }}</a>
+                {%- endif -%}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {%- endfor -%}
+  </div>
+</slideshow-component>
+
+{% schema %}
+{
+  "name": "Pro AGG hero slider",
+  "settings": [
+    {
+      "type": "select",
+      "id": "layout",
+      "label": "Layout",
+      "options": [
+        { "value": "full_bleed", "label": "Full bleed" },
+        { "value": "grid", "label": "Grid" }
+      ],
+      "default": "full_bleed"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_text_below",
+      "label": "Show text below on mobile",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "auto_rotate",
+      "label": "Auto-rotate slides",
+      "default": true
+    },
+    {
+      "type": "range",
+      "id": "change_slides_speed",
+      "label": "Autoplay speed",
+      "min": 3,
+      "max": 9,
+      "step": 1,
+      "unit": "s",
+      "default": 5
+    }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        { "type": "image_picker", "id": "image", "label": "Image" },
+        { "type": "range", "id": "image_overlay_opacity", "label": "Overlay opacity", "min": 0, "max": 100, "step": 10, "default": 0 },
+        { "type": "text", "id": "heading", "label": "Heading", "default": "Heading" },
+        { "type": "textarea", "id": "text", "label": "Text" },
+        { "type": "text", "id": "button_label_1", "label": "Button label 1" },
+        { "type": "url", "id": "button_link_1", "label": "Button link 1" },
+        { "type": "text", "id": "button_label_2", "label": "Button label 2" },
+        { "type": "url", "id": "button_link_2", "label": "Button link 2" },
+        { "type": "select", "id": "text_alignment", "label": "Text alignment", "options": [ { "value": "left", "label": "Left" }, { "value": "center", "label": "Center" }, { "value": "right", "label": "Right" } ], "default": "center" },
+        { "type": "select", "id": "text_alignment_mobile", "label": "Mobile text alignment", "options": [ { "value": "left", "label": "Left" }, { "value": "center", "label": "Center" }, { "value": "right", "label": "Right" } ], "default": "center" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Pro AGG hero slider",
+      "blocks": [
+        { "type": "slide" },
+        { "type": "slide" }
+      ]
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add `pro-agg-hero-slider` section modeled after slideshow with headings, text, and dual CTAs
- include stub styles and script assets for the new hero slider

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fccc2690832eb948a84ac6630f30