### PR TITLE
Add pro-agg-hero-slider section

### DIFF
--- a/assets/pro-agg-hero-slider.css
+++ b/assets/pro-agg-hero-slider.css
@@ -1,0 +1,97 @@
+.pro-agg-hero-slider {
+  position: relative;
+  overflow: hidden;
+}
+
+.pro-agg-hero-slider__slides {
+  display: flex;
+  transition: transform 0.6s ease;
+}
+
+.pro-agg-hero-slider--fade .pro-agg-hero-slider__slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.pro-agg-hero-slider--fade .pro-agg-hero-slider__slide.is-active {
+  opacity: 1;
+  position: relative;
+}
+
+.pro-agg-hero-slider__slide {
+  min-width: 100%;
+  position: relative;
+}
+
+.pro-agg-hero-slider__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+}
+
+.pro-agg-hero-slider__text--left {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.pro-agg-hero-slider__text--right {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.pro-agg-hero-slider__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+.pro-agg-hero-slider__arrow--prev {
+  left: 1rem;
+}
+
+.pro-agg-hero-slider__arrow--next {
+  right: 1rem;
+}
+
+.pro-agg-hero-slider__dots {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.pro-agg-hero-slider__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  border: none;
+  cursor: pointer;
+}
+
+.pro-agg-hero-slider__dot.is-active {
+  background: #fff;
+}
+
+@media (max-width: 749px) {
+  .pro-agg-hero-slider--mobile-contain img {
+    object-fit: contain;
+  }
+
+  .pro-agg-hero-slider--mobile-cover img {
+    object-fit: cover;
+  }
+}

--- a/assets/pro-agg-hero-slider.js
+++ b/assets/pro-agg-hero-slider.js
@@ -1,0 +1,63 @@
+class ProAggHeroSlider {
+  constructor(container) {
+    this.container = container;
+    this.slides = Array.from(container.querySelectorAll('.pro-agg-hero-slider__slide'));
+    this.track = container.querySelector('.pro-agg-hero-slider__slides');
+    this.dots = Array.from(container.querySelectorAll('.pro-agg-hero-slider__dot'));
+    this.prevButton = container.querySelector('.pro-agg-hero-slider__arrow--prev');
+    this.nextButton = container.querySelector('.pro-agg-hero-slider__arrow--next');
+    this.current = 0;
+    this.autoplay = container.dataset.autoplay === 'true';
+    this.speed = parseInt(container.dataset.speed, 10) || 5000;
+    this.transition = container.dataset.transition;
+    this.interval = null;
+
+    this.prevButton.addEventListener('click', () => this.prev());
+    this.nextButton.addEventListener('click', () => this.next());
+    this.dots.forEach((dot, i) => dot.addEventListener('click', () => this.show(i)));
+    container.addEventListener('mouseenter', () => this.pause());
+    container.addEventListener('mouseleave', () => this.play());
+
+    this.show(0);
+    this.play();
+  }
+
+  show(index) {
+    this.slides.forEach((slide, i) => {
+      slide.classList.toggle('is-active', i === index);
+    });
+    this.dots.forEach((dot, i) => dot.classList.toggle('is-active', i === index));
+    if (this.transition === 'slide') {
+      const offset = index * -100;
+      this.track.style.transform = `translateX(${offset}%)`;
+    }
+    this.current = index;
+  }
+
+  next() {
+    const index = (this.current + 1) % this.slides.length;
+    this.show(index);
+  }
+
+  prev() {
+    const index = (this.current - 1 + this.slides.length) % this.slides.length;
+    this.show(index);
+  }
+
+  play() {
+    if (this.autoplay) {
+      this.interval = setInterval(() => this.next(), this.speed);
+    }
+  }
+
+  pause() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.pro-agg-hero-slider').forEach((slider) => new ProAggHeroSlider(slider));
+});

--- a/sections/pro-agg-hero-slider.liquid
+++ b/sections/pro-agg-hero-slider.liquid
@@ -1,0 +1,138 @@
+{{ 'pro-agg-hero-slider.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'pro-agg-hero-slider.js' | asset_url }}" defer="defer"></script>
+
+<div class="pro-agg-hero-slider pro-agg-hero-slider--{{ section.settings.transition_type }} pro-agg-hero-slider--mobile-{{ section.settings.mobile_image_behavior }}" data-autoplay="{{ section.settings.autoplay }}" data-speed="{{ section.settings.autoplay_speed }}" data-transition="{{ section.settings.transition_type }}">
+  <div class="pro-agg-hero-slider__slides">
+    {% for block in section.blocks %}
+      <div class="pro-agg-hero-slider__slide{% if forloop.first %} is-active{% endif %}" {{ block.shopify_attributes }}>
+        {% if block.settings.image != blank %}
+          <picture>
+            {% if block.settings.mobile_image != blank %}
+              <source media="(max-width: 749px)" srcset="{{ block.settings.mobile_image | img_url: '750x' }}">
+            {% endif %}
+            <img src="{{ block.settings.image | img_url: '1500x' }}" alt="{{ block.settings.image.alt | escape }}" loading="lazy">
+          </picture>
+        {% endif %}
+        {% if block.settings.text != blank or block.settings.button_label != blank %}
+          <div class="pro-agg-hero-slider__overlay" style="background-color: rgba(0,0,0, {{ section.settings.overlay_opacity | divided_by: 100.0 }});">
+            <div class="pro-agg-hero-slider__text pro-agg-hero-slider__text--{{ section.settings.text_position }}">
+              {{ block.settings.text }}
+              {% if block.settings.button_label != blank and block.settings.button_link != blank %}
+                <a href="{{ block.settings.button_link }}" class="pro-agg-hero-slider__button">{{ block.settings.button_label }}</a>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+  <button class="pro-agg-hero-slider__arrow pro-agg-hero-slider__arrow--prev" aria-label="Previous slide">&#10094;</button>
+  <button class="pro-agg-hero-slider__arrow pro-agg-hero-slider__arrow--next" aria-label="Next slide">&#10095;</button>
+  <div class="pro-agg-hero-slider__dots">
+    {% for block in section.blocks %}
+      <button class="pro-agg-hero-slider__dot{% if forloop.first %} is-active{% endif %}" aria-label="Go to slide {{ forloop.index }}"></button>
+    {% endfor %}
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Pro AGG Hero Slider",
+  "settings": [
+    {
+      "type": "checkbox",
+      "id": "autoplay",
+      "label": "Autoplay",
+      "default": true
+    },
+    {
+      "type": "range",
+      "id": "autoplay_speed",
+      "label": "Autoplay speed (ms)",
+      "min": 1000,
+      "max": 10000,
+      "step": 500,
+      "default": 5000
+    },
+    {
+      "type": "select",
+      "id": "transition_type",
+      "label": "Slide transition type",
+      "options": [
+        { "value": "slide", "label": "Slide" },
+        { "value": "fade", "label": "Fade" }
+      ],
+      "default": "slide"
+    },
+    {
+      "type": "select",
+      "id": "text_position",
+      "label": "Text position",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ],
+      "default": "center"
+    },
+    {
+      "type": "range",
+      "id": "overlay_opacity",
+      "label": "Overlay opacity",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "default": 40
+    },
+    {
+      "type": "select",
+      "id": "mobile_image_behavior",
+      "label": "Mobile image behavior",
+      "options": [
+        { "value": "cover", "label": "Cover" },
+        { "value": "contain", "label": "Contain" }
+      ],
+      "default": "cover"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "slide",
+      "name": "Slide",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
+        },
+        {
+          "type": "image_picker",
+          "id": "mobile_image",
+          "label": "Mobile image"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "label": "Text"
+        },
+        {
+          "type": "text",
+          "id": "button_label",
+          "label": "Button label"
+        },
+        {
+          "type": "url",
+          "id": "button_link",
+          "label": "Button link"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Pro AGG Hero Slider",
+      "category": "Image"
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,5 +1,9 @@
 {
   "sections": {
+    "pro_agg_hero_slider": {
+      "type": "pro-agg-hero-slider",
+      "settings": {}
+    },
     "image_banner": {
       "type": "image-banner",
       "blocks": {
@@ -69,6 +73,7 @@
     }
   },
   "order": [
+    "pro_agg_hero_slider",
     "image_banner",
     "featured_collection"
   ]


### PR DESCRIPTION
## Summary
- introduce `pro-agg-hero-slider` section with configurable slides, overlay text, CTA buttons, and navigation
- add corresponding styles and script for autoplay, transitions, and responsive behavior
- register hero slider on the home page template for theme editor access

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2013f2a0c832ea82eb79c69e35978